### PR TITLE
Adapt automgtic to oauth2 realities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Make sure to activate the following plugins on mediagoblin ::
 
 Once you have installed the dependencies, you need to have an OAuth client
 registered on the GNU MediaGoblin instance, you can register one at
-``instance.example/oauth/client/register``.
+``instance.example/oauth2/client/register``.
 
 Name it what you want, type should be "Public", and Redirect URI should be "http://www.foo.example/".
 

--- a/automgtic/__init__.py
+++ b/automgtic/__init__.py
@@ -7,7 +7,7 @@ from urllib2 import urlopen, Request
 
 from poster.streaminghttp import register_openers
 from poster.encode import multipart_encode
-from oauthlib.oauth2.draft25 import WebApplicationClient
+from oauthlib.oauth2 import WebApplicationClient
 from configobj import ConfigObj
 from validate import Validator
 


### PR DESCRIPTION
Adapt README to use the oauth2 URL now that mediagoblin uses to
register a new client.

Don't pull in from some oauthlib.oauth.draftXX URL, oauthlib simpliz uses
oauthlib.oauth2 now.
